### PR TITLE
Update POM to current SciJava best practices

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>net.imagej</groupId>
-		<artifactId>pom-imagej</artifactId>
-		<version>16.6.0</version>
+		<groupId>org.scijava</groupId>
+		<artifactId>pom-scijava</artifactId>
+		<version>23.2.0</version>
 		<relativePath />
 	</parent>
 
@@ -14,10 +14,22 @@
 	<version>0.1.0-SNAPSHOT</version>
 
 	<name>imagej-jython-package</name>
-	<description>A minimal environment to package Jython modules with maven.</description>
-	<url>http://imagej.net/jython_scripting</url>
+	<description>A minimal environment to package Jython modules with Maven.</description>
+	<url>http://mycompany.com/imagej/my-jython-scripts/</url>
+	<inceptionYear>2016</inceptionYear>
+	<organization>
+		<name>My Company</name>
+		<url>http://mycompany.com/</url>
+	</organization>
+	<licenses>
+		<license>
+			<name>Simplified BSD License</name>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
 
 	<developers>
+		<!-- See https://imagej.net/Team -->
 		<developer>
 			<id>m-entrup</id>
 			<name>Michael Entrup</name>
@@ -25,8 +37,40 @@
 			<url>https://m-entrup.de</url>
 		</developer>
 	</developers>
+	<contributors>
+		<!--
+		NB: Need at least one element to override the parent.
+		See: https://issues.apache.org/jira/browse/MNG-5220
+		-->
+		<contributor>
+			<name>None</name>
+		</contributor>
+	</contributors>
+
+	<mailingLists>
+		<mailingList>
+			<name>Image.sc Forum</name>
+			<archive>https://forum.image.sc/</archive>
+		</mailingList>
+	</mailingLists>
+
+	<scm>
+		<connection>scm:git:git://github.com/m-entrup/imagej-jython-package</connection>
+		<developerConnection>scm:git:git@github.com:m-entrup/imagej-jython-package</developerConnection>
+		<tag>HEAD</tag>
+		<url>https://github.com/m-entrup/imagej-jython-package</url>
+	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/m-entrup/imagej-jython-package/issues</url>
+	</issueManagement>
+	<ciManagement>
+		<system>None</system>
+	</ciManagement>
 
 	<properties>
+		<license.licenseName>bsd_2</license.licenseName>
+		<license.copyrightOwners>My Company, Inc.</license.copyrightOwners>
 		<maven.source.skip>true</maven.source.skip>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-		http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -9,36 +9,36 @@
 		<artifactId>pom-imagej</artifactId>
 		<version>16.6.0</version>
 		<relativePath />
-</parent>
+	</parent>
 
-<groupId>net.imagej</groupId>
-<artifactId>imagej-jython-package</artifactId>
-<version>0.1.0-SNAPSHOT</version>
-<packaging>jar</packaging>
+	<groupId>net.imagej</groupId>
+	<artifactId>imagej-jython-package</artifactId>
+	<version>0.1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
 
-<name>imagej-jython-package</name>
-<description>A minimal environment to package Jython modules with maven.</description>
-<url>http://imagej.net/jython_scripting</url>
+	<name>imagej-jython-package</name>
+	<description>A minimal environment to package Jython modules with maven.</description>
+	<url>http://imagej.net/jython_scripting</url>
 
 	<dependencies>
 		<dependency>
 			<groupId>net.imagej</groupId>
 			<artifactId>ij</artifactId>
 		</dependency>
-</dependencies>
+	</dependencies>
 
-<build>
-	<plugins>
-		<!-- Do not generate a source jar -->
-		<plugin>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-source-plugin</artifactId>
-			<configuration>
-				<skipSource>true</skipSource>
-			</configuration>
-		</plugin>
-	</plugins>
-</build>
+	<build>
+		<plugins>
+			<!-- Do not generate a source jar -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<configuration>
+					<skipSource>true</skipSource>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 	<developers>
 		<developer>
@@ -47,12 +47,12 @@
 			<email>mail@m-entrup.de</email>
 			<url>https://m-entrup.de</url>
 		</developer>
-</developers>
+	</developers>
 
-<repositories>
-	<repository>
-		<id>imagej.public</id>
-		<url>http://maven.imagej.net/content/groups/public</url>
-	</repository>
-</repositories>
+	<repositories>
+		<repository>
+			<id>imagej.public</id>
+			<url>http://maven.imagej.net/content/groups/public</url>
+		</repository>
+	</repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-	http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -18,13 +16,6 @@
 	<name>imagej-jython-package</name>
 	<description>A minimal environment to package Jython modules with maven.</description>
 	<url>http://imagej.net/jython_scripting</url>
-
-	<dependencies>
-		<dependency>
-			<groupId>net.imagej</groupId>
-			<artifactId>ij</artifactId>
-		</dependency>
-	</dependencies>
 
 	<developers>
 		<developer>
@@ -45,4 +36,11 @@
 			<url>http://maven.imagej.net/content/groups/public</url>
 		</repository>
 	</repositories>
+
+	<dependencies>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij</artifactId>
+		</dependency>
+	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
 	<groupId>net.imagej</groupId>
 	<artifactId>imagej-jython-package</artifactId>
 	<version>0.1.0-SNAPSHOT</version>
-	<packaging>jar</packaging>
 
 	<name>imagej-jython-package</name>
 	<description>A minimal environment to package Jython modules with maven.</description>
@@ -27,19 +26,6 @@
 		</dependency>
 	</dependencies>
 
-	<build>
-		<plugins>
-			<!-- Do not generate a source jar -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<configuration>
-					<skipSource>true</skipSource>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-
 	<developers>
 		<developer>
 			<id>m-entrup</id>
@@ -48,6 +34,10 @@
 			<url>https://m-entrup.de</url>
 		</developer>
 	</developers>
+
+	<properties>
+		<maven.source.skip>true</maven.source.skip>
+	</properties>
 
 	<repositories>
 		<repository>


### PR DESCRIPTION
This PR updates the project POM to extend pom-scijava instead of the deprecated pom-imagej. It also adds important project metadata, similar to [example-imagej-command](https://github.com/imagej/example-imagej-command) and [example-legacy-plugin](https://github.com/imagej/example-legacy-plugin).